### PR TITLE
Update to new magitek.zip download link. The previous zip was the old…

### DIFF
--- a/ddls.json
+++ b/ddls.json
@@ -1,7 +1,7 @@
 {
 	"Magitek": [
 		"Routines",
-		"https://cdn.discordapp.com/attachments/332630645849325568/609113079896211543/Magitek.zip",
+		"https://cdn.discordapp.com/attachments/332630645849325568/989323185654743060/Magitek.zip",
 		"Formerly Paid combat routine"
 	],
 	"Lisbeth": [


### PR DESCRIPTION
… build server and does not work.

Magitek changed build servers a while ago, this fixes the download to point to the newest zip which has an updated loader. 

This can be verified here: https://ptb.discord.com/channels/306270308501815307/332630645849325568/989323185944141824

Or here: https://ptb.discord.com/channels/306270308501815307/306270308501815307/1115724828838740069
